### PR TITLE
fix: Removed two interfering rules

### DIFF
--- a/src/eslint/index.ts
+++ b/src/eslint/index.ts
@@ -30,11 +30,6 @@ export const EslintVenlocRecommended: ConfigWithExtends = {
     "no-unused-vars": "warn",
     "use-isnan": "error",
     /* Suggestions */
-    "capitalized-comments": [
-      "warn",
-      "always",
-      { ignoreInlineComments: true, ignoreConsecutiveComments: true },
-    ],
     eqeqeq: ["error", "smart"],
     "guard-for-in": "error",
     "no-alert": "error",

--- a/src/typelint/index.ts
+++ b/src/typelint/index.ts
@@ -15,7 +15,7 @@ export const TypelintVenlocRecommended: ConfigWithExtends = {
     "@typescript-eslint/no-array-delete": "error",
     "@typescript-eslint/no-duplicate-enum-values": "error",
     "@typescript-eslint/no-duplicate-type-constituents": "warn",
-    "@typescript-eslint/no-explicit-any": ["warn", { ignoreRestArgs: true }],
+    // "@typescript-eslint/no-explicit-any": ["warn", { ignoreRestArgs: true }],
     "@typescript-eslint/no-extra-non-null-assertion": "error",
     "@typescript-eslint/no-import-type-side-effects": "error",
     "@typescript-eslint/no-inferrable-types": "warn",


### PR DESCRIPTION
### What changed
After using this rules in projects we decided to make some changes with: `capitalized-comments` & `no-explicit-any`.

#### Capitalized-comments
This rule has one critical flaw. When you comment code lines it automaticle conver first char to upper-case. F.E. If we comment import line:
```tsx
import VenlocRecommended from "@venloc-tech/Typelint";
```
It's changed to:
```tsx
// Import VenlocRecommended from "@venloc-tech/Typelint";
```
This is breaking behaviour after uncomment and add useless changes

#### No-explicit-any
Even though the rule was used with `warn` level, all `any` uses mark as error and suggest to change this to `never` or `unknown`. We also recommend not to use `any` but in some case -- we need it. Unfortunately rule is ruined some app logics.




